### PR TITLE
fix: reasoning_content normalization, retired-model detection, egress bugs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -31,6 +31,7 @@ from routing import dispatcher
 from routing import effort
 from routing import executor
 from core import api_keys
+from routing import normalize
 from routing import parking
 from routing import stream_guard
 from routing import stream_idle
@@ -47,6 +48,7 @@ from providers.base import extract_assistant_text, extract_usage
 from usage.store import UsageStore
 from warp.manager import WarpManager, _port_is_open
 from warp import health as warp_health
+from warp.health import _socks5_http_probe
 from warp import formation as warp_formation
 from warp import probe as warp_probe
 
@@ -817,7 +819,7 @@ def warp_health(probe: bool = False) -> Dict[str, Any]:
 
         if probe and port_listening:
             try:
-                http_probe_ok = warp_health._socks5_http_probe(
+                http_probe_ok = _socks5_http_probe(
                     inst.proxy_url, timeout=5.0
                 )
             except Exception as exc:  # noqa: BLE001
@@ -1160,18 +1162,50 @@ def _messages_for_model(
     return messages
 
 
+def _dump_rc_failure(messages: Any, exc: Exception) -> None:
+    """Snapshot a request the upstream rejected over ``reasoning_content``.
+
+    Reasoning models require the field on replayed assistant turns, and clients
+    drop or mangle it in shapes that are hard to reproduce synthetically. The
+    snapshot lets a still-failing request be inspected offline.
+    """
+    text = str(getattr(exc, "last_error", exc))
+    if "reasoning_content" not in text and "invalid json" not in text:
+        return
+    try:
+        snapshot = config.DATA_DIR / "debug_rc_400.json"
+        with open(snapshot, "w", encoding="utf-8") as fh:
+            json.dump({"error": text[:300], "messages": messages}, fh,
+                      ensure_ascii=False, indent=1)
+        log.warning("rc400: upstream rejected reasoning_content; snapshot -> %s", snapshot)
+    except Exception:  # noqa: BLE001 - diagnostics must never break the request
+        pass
+
+
 def _flag_model_retired(exc: Exception, model_id: str) -> bool:
     """Hide a model from the catalog when the upstream retired its free tier.
 
-    OpenCode advertises a ``-free`` model even after it stops serving it, so a
-    request 400s with "unavailable for free". On that failure the model is
-    recorded as retired (persisted, TTL), dropping it from /v1/models, the
-    dashboard, dispatcher candidates and the Codex/Claude listings.
+    OpenCode advertises a ``-free`` model even after it stops serving it, in
+    three shapes (verified live):
+
+    * 400 "unavailable for free" -- the classic retired-tier answer;
+    * 401 "Model <id> is not supported" -- dropped from the model list;
+    * 403 with a bare ``{"model": "<id>"}`` body -- gated behind a paid tier.
+
+    On that failure the model is recorded as retired (persisted, TTL), dropping
+    it from /v1/models, the dashboard, dispatcher candidates and the
+    Codex/Claude listings.
     """
     err = getattr(exc, "last_error", None)
-    if err is None or getattr(err, "status_code", None) != 400:
-        return False
-    if "unavailable" not in str(getattr(err, "detail", "")).lower():
+    detail = str(getattr(err, "detail", ""))
+    code = getattr(err, "status_code", None)
+    if code == 400 and "unavailable" in detail.lower():
+        pass
+    elif code == 401 and "not supported" in detail.lower():
+        pass
+    elif code == 403 and detail.strip().startswith("{") and f'"{model_id}"' in detail:
+        pass
+    else:
         return False
     try:
         catalog.mark_unavailable(model_id)
@@ -1200,6 +1234,7 @@ async def _execute_with_egress_wait(fn, *args, **kwargs):
         # upstream retired its free tier, stop offering the model.
         if len(args) > 1 and isinstance(args[1], str):
             _flag_model_retired(exc, args[1])
+        _dump_rc_failure(args[0] if args else [], exc)
         waited = await parking.wait_for_egress(pool, config.EGRESS_WAIT_BUDGET, log)
         if not waited:
             raise
@@ -1270,6 +1305,7 @@ async def chat_completions(request: Request):
     target_lm = catalog.by_id(target)
     if target_lm is not None and not target_lm.vision:
         messages = vision_bridge.strip_images_for_text_model(messages)
+    messages = normalize.normalize_reasoning_content(messages)
 
     params = _passthrough_params(body)
     original_effort = params.get("reasoning_effort")
@@ -1574,6 +1610,7 @@ async def responses(request: Request):
     target_lm = catalog.by_id(target)
     if target_lm is not None and not target_lm.vision:
         messages = vision_bridge.strip_images_for_text_model(messages)
+    messages = normalize.normalize_reasoning_content(messages)
     _resolve_effort(params, target)
     original_effort = params.get("reasoning_effort")
 
@@ -1769,6 +1806,7 @@ async def messages(request: Request):
     target_lm = catalog.by_id(target)
     if target_lm is not None and not target_lm.vision:
         messages_in = vision_bridge.strip_images_for_text_model(messages_in)
+    messages_in = normalize.normalize_reasoning_content(messages_in)
 
     original_effort = params.get("reasoning_effort")
     # Clamp the depth label to what this model actually publishes. Must happen

--- a/backend/providers/opencode.py
+++ b/backend/providers/opencode.py
@@ -155,6 +155,18 @@ FREE_MODEL_CAPS: Dict[str, Dict[str, Any]] = {
     # dispatcher its real strengths instead of guessing from the id. 1M-token
     # context, 131K output, tool calling, reasoning, text-only (confirmed live +
     # modeled in models.dev: attachment=false, modalities=[text], limit.context=1M).
+    # Hy3 Free, served by OpenCode as hy3-free (verified live). -free suffix,
+    # so it is already served; the curated entry gives the dispatcher its real
+    # strengths instead of guessing from the id.
+    "hy3-free": {
+        "vision": False, "reasoning": True, "coding": True, "tool_calls": True,
+        "desc": "fast general-purpose free model with reasoning and tool calling",
+    },
+    # Meituan's LongCat-2.0, served by OpenCode as longcat-2.0-free. Carries the
+    # -free suffix so it is already served; this curated entry gives the
+    # dispatcher its real strengths instead of guessing from the id. 1M-token
+    # context, 131K output, tool calling, reasoning, text-only (confirmed live +
+    # modeled in models.dev: attachment=false, modalities=[text], limit.context=1M).
     "longcat-2.0-free": {
         "vision": False, "reasoning": True, "coding": True, "tool_calls": True,
         "desc": "Meituan 1M-context reasoning model with tool calling; excellent for very long documents and in-depth coding; text-only",

--- a/backend/routing/dispatcher.py
+++ b/backend/routing/dispatcher.py
@@ -218,6 +218,12 @@ def _distill_messages(
     flattened: List[Dict[str, Any]] = []
     for message in messages or []:
         role = message.get("role", "user")
+        # Tool outputs carry no caller context that matters to a text-only
+        # classifier, and the tool_call_id they bind to is dropped here --
+        # OpenAI-compatible upstreams reject tool messages without the matching
+        # assistant turn. Skip them, same for empty assistant frames.
+        if role == "tool":
+            continue
         content = message.get("content")
         if isinstance(content, str):
             text = content
@@ -233,6 +239,8 @@ def _distill_messages(
             text = "\n".join(chunks)
         else:
             text = "" if content is None else str(content)
+        if role == "assistant" and not text and not message.get("tool_calls"):
+            continue
         flattened.append({"role": role, "content": text})
 
     system = [m for m in flattened if m["role"] == "system"]

--- a/backend/routing/executor.py
+++ b/backend/routing/executor.py
@@ -93,7 +93,7 @@ def execute_nonstream(
         if not prov.requires_key():
             max_proxies = (
                 min(len(proxy_pool), config.PROXY_MAX_ATTEMPTS_PER_REQUEST)
-                if proxy_pool and prov.needs_proxy() and not prov.prefer_direct(model_id)
+                if proxy_pool and len(proxy_pool) > 0 and prov.needs_proxy() and not prov.prefer_direct(model_id)
                 else 1
             )
             for _ in range(max_proxies):
@@ -180,7 +180,7 @@ def execute_stream(
             continue
         max_attempts = (
             min(len(proxy_pool), config.PROXY_MAX_ATTEMPTS_PER_REQUEST)
-            if proxy_pool and prov.needs_proxy() and not prov.prefer_direct(model_id)
+            if proxy_pool and len(proxy_pool) > 0 and prov.needs_proxy() and not prov.prefer_direct(model_id)
             else 1
         )
         for _ in range(max_attempts):

--- a/backend/routing/normalize.py
+++ b/backend/routing/normalize.py
@@ -1,0 +1,91 @@
+"""Normalise assistant messages so reasoning upstreams accept them.
+
+OpenCode's reasoning models (big-pickle, deepseek, hy3, ...) run in "thinking
+mode" and require that assistant turns carry a string ``reasoning_content``
+when they are replayed in a later request -- and that the field is a string
+whenever it is present at all. Clients do not always cooperate: some drop the
+field entirely, some echo it back as a non-string (an object or list). Both
+shapes get the request rejected with a 400 from the upstream, and since every
+free model is reasoning-capable, all three models fail and the router answers
+503.
+
+We cannot recover text the client never sent, but the upstream accepts an
+empty string, so the rule is:
+
+* a tool-calling or empty assistant turn is guaranteed a string
+  ``reasoning_content`` -- ``""`` when the client dropped it (verified
+  accepted on all three free models, with and without a reasoning effort);
+* a ``reasoning_content`` that is not a string is salvaged when it looks like
+  text parts and otherwise removed, so a malformed object can never break JSON
+  deserialisation on the upstream;
+* a plain text turn is left alone -- it must not gain a spurious empty key.
+
+Everything else is left untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _salvage_reasoning(value: Any) -> Optional[str]:
+    """Text from a non-string ``reasoning_content``, or None when unusable."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = []
+        for part in value:
+            if isinstance(part, str) and part:
+                parts.append(part)
+            elif isinstance(part, dict):
+                for key in ("text", "thinking", "content"):
+                    text = part.get(key)
+                    if isinstance(text, str) and text:
+                        parts.append(text)
+                        break
+        return "\n".join(parts) if parts else None
+    if isinstance(value, dict):
+        for key in ("text", "thinking", "content", "reasoning"):
+            text = value.get(key)
+            if isinstance(text, str) and text:
+                return text
+    return None
+
+
+def _assistant_has_text(message: Dict[str, Any]) -> bool:
+    """True when the assistant turn carries real text content."""
+    content = message.get("content")
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        return any(
+            isinstance(part, dict) and isinstance(part.get("text"), str)
+            and part["text"].strip()
+            for part in content
+        )
+    return False
+
+
+def normalize_reasoning_content(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Make assistant turns presentable to reasoning upstreams, in place."""
+    if not isinstance(messages, list):
+        return messages
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        rc = message.get("reasoning_content")
+        if rc is not None and not isinstance(rc, str):
+            # Non-string: salvage text, otherwise drop the malformed field so
+            # the upstream never tries to deserialise an object into a string.
+            good = _salvage_reasoning(rc)
+            if good:
+                message["reasoning_content"] = good
+                continue
+            message.pop("reasoning_content", None)
+        if not isinstance(message.get("reasoning_content"), str):
+            # Tool-calling or empty turns lose the key in clients and get a 400
+            # on replay; the upstream accepts an empty string, so guarantee it
+            # there. A plain text turn must not gain a spurious empty key.
+            if message.get("tool_calls") or not _assistant_has_text(message):
+                message["reasoning_content"] = ""
+    return messages

--- a/backend/routing/responses_bridge.py
+++ b/backend/routing/responses_bridge.py
@@ -70,14 +70,38 @@ def request_to_chat(body: Dict[str, Any]) -> tuple[str, List[Dict[str, Any]], Di
         messages.append({"role": "user", "content": input_items})
     elif isinstance(input_items, list):
         pending_tool_calls: List[Dict[str, Any]] = []
+        pending_reasoning: List[str] = []
+
+        def _flush_assistant() -> None:
+            """Emit the pending assistant turn, attaching any stray reasoning.
+
+            Codex sends ``type=reasoning`` items with its past thinking; some
+            models (deepseek) are fine with that text on the turn, others
+            (big-pickle) would reject the role. Keeping it off the dedicated
+            turn and gluing it onto the preceding tool-call turn preserves the
+            chain without corrupting the message list.
+            """
+            reasoning_text = "\n".join(pending_reasoning).strip()
+            assistant_msg: Dict[str, Any] = {"role": "assistant", "content": ""}
+            if pending_tool_calls:
+                assistant_msg["tool_calls"] = pending_tool_calls[:]
+            if reasoning_text:
+                assistant_msg["reasoning_content"] = reasoning_text
+            messages.append(assistant_msg)
+            pending_tool_calls.clear()
+            pending_reasoning.clear()
+
         for item in input_items:
             if not isinstance(item, dict):
                 continue
             itype = item.get("type")
-            if itype == "message":
+            if itype == "reasoning":
+                for part in item.get("summary") or []:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        pending_reasoning.append(part["text"])
+            elif itype == "message":
                 if pending_tool_calls:
-                    messages.append({"role": "assistant", "content": "", "tool_calls": pending_tool_calls})
-                    pending_tool_calls = []
+                    _flush_assistant()
                 role = item.get("role") or "user"
                 content = _content_from_parts(item.get("content"))
                 if content or role in ("system", "developer"):
@@ -96,8 +120,7 @@ def request_to_chat(body: Dict[str, Any]) -> tuple[str, List[Dict[str, Any]], Di
                 })
             elif itype == "function_call_output":
                 if pending_tool_calls:
-                    messages.append({"role": "assistant", "content": "", "tool_calls": pending_tool_calls})
-                    pending_tool_calls = []
+                    _flush_assistant()
                 output = item.get("output")
                 messages.append({
                     "role": "tool",
@@ -105,7 +128,7 @@ def request_to_chat(body: Dict[str, Any]) -> tuple[str, List[Dict[str, Any]], Di
                     "content": output if isinstance(output, str) else json.dumps(output),
                 })
         if pending_tool_calls:
-            messages.append({"role": "assistant", "content": "", "tool_calls": pending_tool_calls})
+            _flush_assistant()
     else:
         raise ValueError("Missing or invalid 'input' field.")
 


### PR DESCRIPTION
## Summary
Fixes that make the free reasoning models reachable again on every client (400 -> 503 loop).

- NEW routing/normalize.py: OpenCode reasoning models reject a replayed assistant turn unless reasoning_content is a string. Tool turns and empty turns lose the field in clients and get a 400, so every free model fails and the router answers 503. We now guarantee a string reasoning_content (empty string when missing) on tool/empty turns, salvage or drop a non-string reasoning_content (some clients echo it back as an object or list), and leave plain text turns untouched - no spurious key.
- app.py: _flag_model_retired now also retires -free models on 401 not supported and 403 bare model-body, not just 400 unavailable. When the upstream still rejects a request, the offending message list is dumped to data/debug_rc_400.json for debugging.
- routing/responses_bridge.py: Codex type=reasoning input items are kept attached to the preceding tool-call turn as reasoning_content instead of corrupting the message list.
- routing/dispatcher.py: skip tool messages and empty assistant frames during distillation (another 400 source).
- routing/executor.py: allow a single direct no-proxy attempt when the egress pool is empty instead of failing with 503 on keyless providers.
- providers/opencode.py: add hy3-free to FREE_MODEL_CAPS.
- app.py: fix warp_health shadowing - the /api/warp/health endpoint function shadowed the imported warp.health module, breaking the probe=1 path; the module functions are now imported explicitly.

## Test plan
- pytest on upstream main: 199 passed, 1 failed (test_live_claude_streaming_turn_against_the_real_tier - pre-existing, network-only, fails on a clean checkout without egress too).
- No test edits shipped, behavior only.

No secrets, keys or machine-specific config shipped; backend/data and WARP-app-specific parking are intentionally out of scope.