### PR TITLE
fix(recycler): retire on 'unavailable' 400 regardless of /models listing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,26 +189,39 @@ over to another free one.
 
 ### The retirement cycle
 
-Upstream sometimes keeps advertising a model it no longer actually serves. The
-first request that hits a 400 retires it — but only for a while, because OpenCode
-has restored free tiers before:
+Upstream sometimes keeps advertising a model it no longer actually serves — the
+list says free, the chat says no. The first request that hits a 400 retires the
+model **regardless of the listing**. It stays hidden for a probation window,
+after which the catalog's self-heal can resurrect it on a live re-list, because
+OpenCode has restored free tiers before:
 
 ```mermaid
 stateDiagram-v2
     direction LR
     [*] --> Listed: appears in live feed
-    Listed --> Retired: request returns 400
-    Retired --> Listed: 7 days pass, model works again
-    Retired --> Retired: still dead → re-retired
+    Listed --> Retired: chat returns "unavailable" 400
+    Retired --> Listed: probation elapses & live re-list holds
+    Retired --> Retired: still dead after probation → re-retired
     note right of Retired
         hidden from Catalog
         survives restarts
     end note
 ```
 
-Models already known to be gone are pre-seeded as retired (`LINGLING_RETIRED_MODELS`)
-so they never list even once. The seven-day window is
-`LINGLING_RETIRED_MODEL_TTL_DAYS`.
+The five-minute probation window (`LINGLING_RETIRED_MODEL_PROBATION_S`) replaced
+the older "trust `/models`" gate, which kept chronic offenders (still listed but
+the upstream keeps refusing chat — the deepseek/musespark case) perpetually
+routable. A model that just 400'd once rides out a transient blip in five
+minutes instead of the seven-day lockdown the old design used to lock out
+working models for; a chronic offender cycles parked → retried → re-parked once
+per window until opencode actually restores the chat.
+
+`LINGLING_RETIRED_MODEL_TTL_DAYS` (7 days) is now the upper-bound age cap — a
+retired entry older than this is dropped on a fresh gateway start. Probation
+re-parks reset the timer, so a chronic offender that keeps cycling never ages
+out; the TTL only garbage-collects entries that genuinely went idle for over a
+week. Models already known to be gone are pre-seeded as retired
+(`LINGLING_RETIRED_MODELS`) so they never list even once.
 
 ## Reasoning effort
 
@@ -322,7 +335,8 @@ gateway. Skip this section unless something specific needs changing.
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `LINGLING_RETIRED_MODELS` | *(seeded list)* | Models hidden from the catalog from startup — dropped free models the upstream still advertises |
-| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | How long a retirement lasts before the model is retried |
+| `LINGLING_RETIRED_MODEL_PROBATION_S` | `300` | A runtime-retired model stays hidden this many seconds before the catalog self-heal can resurrect it on a live `/models` re-list; the window that replaced the old "trust `/models`" gate |
+| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | Upper-bound age cap — a retired entry older than this is dropped on a fresh gateway start (probation re-parks reset the timer, so chronic offenders never age out) |
 | `LINGLING_UPSTREAM_USER_AGENT` | `opencode/1.0` | Identifies as the official client. See below — without this, the best free models 429 instantly |
 
 The complete list lives in `backend/core/config.py`, defaults included. Everything

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You know free AI tiers. They work beautifully for twenty minutes, then a per-IP 
 
 It also:
 - auto-discovers whatever free models opencode is serving *right now* — no frozen model table, because any list would be wrong within a month;
-- retires models opencode quietly stopped serving (learned at runtime, persists across restarts, auto-revives if opencode puts them back);
+- retires models opencode quietly stopped serving at chat, even when `/models` keeps advertising them (the deepseek/musespark chronic case), persists across restarts, and self-heals under a probation clock when opencode actually restores the chat;
 - sends a real probe request through every WARP lane at startup and every few minutes, so dead/burned IPs get re-rolled before your request finds them;
 - runs a tiny non-stream sampler after each heal that pokes every free model through every green exit and records which ones came back **cooked** — yes, that's the technical term — so a model-side refusal fails fast instead of churning the whole pool, and the per-model fallback fires.
 
@@ -57,10 +57,10 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 
 Whatever's free right now — the catalog is fetched live from the upstream at runtime, so there's deliberately no model table here. The defaults currently in play (the sampler's sweep order) are `deepseek-v4-flash-free`, `muse-spark-1.2-contributor-free`, `nemotron-3-ultra-free`, `north-mini-code-free`, `big-pickle`, `longcat-2.0-free`, `laguna-s-2.1-free`; the router's own brain is `deepseek-v4-flash-free`, because it's free, fast, large-context, and text-only. If one of these vanishes, the catalog drops it on the next refresh and the request path fails over to another free model.
 
-A quirk worth knowing: opencode **still advertises some pulled free models in `/v1/models`** even after the CLI drops them — the list lies. Lingling trusts the live list anyway (you told it to), learns the truth at chat-time, and routes a request to a refused model onto a live one transparently. So "this model works" and "this model is listed" are not the same sentence, and that's by design.
+A quirk worth knowing: opencode **still advertises some pulled free models in `/v1/models`** even after the CLI drops them — the list lies. Lingling learns the truth at chat-time, retires a refused model regardless of the listing (see the recycler below), and routes the request onto a live one transparently. So "this model works" and "this model is listed" are not the same sentence, and that's by design.
 
 ### The recycler (retirement cycle)
-First request that comes back with the "unavailable for free" 400 retires the model — hidden from the dashboard picker, `/v1/models`, `/api/models`, and the Codex/Claude Code setup catalogs — for `LINGLING_RETIRED_MODEL_TTL_DAYS` (7 days by default), because opencode has restored free tiers before. A model that genuinely vanishes from `/models` falls out on the next refresh (≤ 10 min, or immediately on dashboard load). Operator-seeded dead ids (`LINGLING_RETIRED_MODELS`, default `ling-3.0-flash-free`) are hidden from the very first startup. The recycler trusts `/models`, and so should you.
+First request that comes back with the "unavailable for free" 400 retires the model — hidden from the dashboard picker, `/v1/models`, `/api/models`, and the Codex/Claude Code setup catalogs — **regardless of whether `/models` still advertises it** (the chronic case: list says free, chat says no). The model stays hidden for `LINGLING_RETIRED_MODEL_PROBATION_S` (5 minutes by default); after that the catalog self-heal can resurrect it on a live re-list, so a transient upstream blip self-heals in minutes, not the seven-day lockdown the old "trust `/models`" design used to lock out working models for. Chronic offenders — `/models` keeps advertising but chat keeps refusing — cycle parked → retried → re-parked once per probation window until opencode actually restores the chat. Operator-seeded dead ids (`LINGLING_RETIRED_MODELS`, default `ling-3.0-flash-free`) are hidden from the very first startup. The recycler trusts the 400, not the listing.
 
 ## The egress pool, a.k.a. the part that sounds illegal
 
@@ -118,7 +118,8 @@ All `LINGLING_*` environment variables, all read once at startup, all with defau
 | variable | default | what it does |
 |---|---|---|
 | `LINGLING_RETIRED_MODELS` | `ling-3.0-flash-free` | known-dead ids hidden from the catalog from the very first startup (opencode keeps advertising them) |
-| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | how long a runtime-learned retirement lasts before the model is retried |
+| `LINGLING_RETIRED_MODEL_PROBATION_S` | `300` | how long a runtime-retired model stays hidden before the catalog self-heal can resurrect it on a live `/models` re-list; a chronic offender (still listed but chat refuses) cycles parked → retried → re-parked every window |
+| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | upper-bound age cap — a retired entry older than this is dropped on a fresh gateway start; probation re-parks reset the timer, so a chronic offender cycling on probation never ages out |
 
 **Sampler + streaming**
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1354,17 +1354,21 @@ _retire_lock = threading.Lock()
 
 
 def _flag_model_retired(exc: Exception, model_id: str) -> bool:
-    """Hide a model from the catalog only when OpenCode actually dropped it.
+    """Hide a model from the catalog when its free-tier chat starts 400-ing.
 
-    A ``-free`` model that 400s with "unavailable" while *still listed* in the
-    free section is transient overload (huge upstream traffic), not removal:
-    OpenCode pulls a genuinely-dropped model from the free section outright, it
-    doesn't answer "unavailable" for one it deleted. Retiring a still-listed
-    model here would hide it from routing/dispatcher for the full TTL (7 days)
-    just because the upstream was busy -- exactly the break MuseSpark and
-    deepseek kept hitting. So a refresh is forced and the model is retired ONLY
-    when it is no longer in the catalog's free list. A per-model cooldown keeps
-    a burst of "unavailable" 400s from forcing more than one refresh per window.
+    A ``-free`` model that comes back from upstream with HTTP 400 "Model is
+    unavailable" has stopped being served free, even when OpenCode keeps
+    advertising it in /models -- and it keeps advertising them: the chronic
+    deepseek/musespark case is "still listed, but the backend refuses chat".
+    So the model is retired here on that signal alone; the chat path's own
+    AllFailedError already propagates to failover, and this drop keeps the
+    same model off the dashboard, /v1/models, the sampler and the dispatcher
+    until the self-heal in catalog.refresh() resurrects it under a probation
+    window (config.RETIRED_MODEL_PROBATION_S). That probation bounds the time
+    a *transient* "unavailable" burst stays parked to minutes -- not the full
+    7-day TTL the old "trust /models" gate used to lock out working models
+    like MuseSpark/deepseek for. A per-model cooldown keeps a burst of
+    "unavailable" 400s from firing more than one retirement per window.
     """
     err = getattr(exc, "last_error", None)
     if err is None or getattr(err, "status_code", None) != 400:
@@ -1376,30 +1380,25 @@ def _flag_model_retired(exc: Exception, model_id: str) -> bool:
     with _retire_lock:
         last = _retire_recheck_at.get(model_id, 0.0)
         if now - last < config.RETIRE_RECHECK_COOLDOWN_S:
-            # Checked recently and it was still listed (else it would have been
-            # retired); don't hammer /models on every concurrent 400 in this burst.
+            # Decisive retirement attempt already made recently for this model;
+            # don't hammer the lock / persisted-retired set on every concurrent
+            # 400 in this burst. Self-heal alone may resurrect it later.
             return False
         _retire_recheck_at[model_id] = now
 
-    # Authoritative answer: force a refresh and see whether the model is still
-    # offered free. refresh() falls back to the last good list on a fetch
-    # failure, so a transient /models outage can't make us retire a model that
-    # is still listed.
-    try:
-        catalog.refresh(force=True)
-    except Exception:  # noqa: BLE001
+    if catalog.is_unavailable(model_id):
+        # Already parked -- the parked_at anchor is the probation clock, so
+        # let it ride and keep the self-heal window anchored to the original
+        # failure rather than re-stamping on concurrent in-flight 400s.
         return False
-    if catalog.by_id(model_id) is not None:
-        # Still in the free section -> genuinely transient, not removed. Leave
-        # it routable; the request's own 400 already propagates to failover.
-        return False
+
     try:
         catalog.mark_unavailable(model_id)
     except Exception:  # noqa: BLE001
         return False
     log.info(
-        "catalog: retired model %s (no longer in the free section; the "
-        "'unavailable' 400 was OpenCode dropping it, not a transient outage)",
+        "catalog: retired model %s (upstream refused free-tier chat with "
+        "'unavailable' 400; self-heal will retry it after RETIRED_MODEL_PROBATION_S)",
         model_id,
     )
     return True

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -146,12 +146,26 @@ def retired_seed_ids() -> frozenset:
     """
     return frozenset(m.strip() for m in RETIRED_MODELS_SEED.split(",") if m.strip())
 
-# Cooldown on the "is this model actually gone from the free section?" recheck
-# that gates runtime retirement (see _flag_model_retired in app.py). A model
-# 400ing "unavailable" under heavy upstream load fires that recheck on many
-# concurrent requests at once; this bounds it to one catalog refresh per model
-# per window so a burst of transient "unavailable" 400s doesn't hammer /models.
+# Cooldown on the runtime retirement attempt itself (see _flag_model_retired
+# in app.py). A model 400ing "unavailable" under heavy upstream load fires
+# that attempt on many concurrent requests at once; this bounds it to one
+# retirement decision per model per window so a burst of transient
+# "unavailable" 400s doesn't hammer the lock or the persisted retired set.
 RETIRE_RECHECK_COOLDOWN_S = float(os.getenv("LINGLING_RETIRE_RECHECK_COOLDOWN_S", "30"))
+# Probation window that a runtime-retired model stays hidden before the
+# catalog self-heal is allowed to resurrect it on a /models re-list. The
+# recycler now retires a model on the first "Model is unavailable" 400 even
+# when OpenCode keeps advertising it in /models (the chronic deepseek/musespark
+# case: still listed, but the upstream refuses to serve chat). Without a
+# probation floor the self-heal in refresh() would resurrect such a model on
+# the very next refresh and the retirement would last ~30s -- useless. The
+# probation keeps it parked for this many seconds; on expiry a live non-stale
+# re-list is allowed to bring it back, so a transient blip self-heals in
+# minutes (not the 7-day TTL the old design used to lock out working models
+# for), while a chronic offender cycles parked -> retried -> re-parked.
+# 0 disables probation (immediate resurrect on the next live re-list, the
+# pre-engine-fix behavior).
+RETIRED_MODEL_PROBATION_S = float(os.getenv("LINGLING_RETIRED_MODEL_PROBATION_S", "300"))
 
 # Defer re-rolling/restarting an egress (WARP wireproxy / Tor lane) while an
 # HTTP stream is riding it, so the health/formation/probe daemons don't

--- a/backend/models/catalog.py
+++ b/backend/models/catalog.py
@@ -244,21 +244,31 @@ class UnifiedCatalog:
             self._per_provider = per_provider
             self._generated_at = time.time()
 
-            # Self-heal runtime retirements against the live free section. A
-            # -free model retired at runtime was absent from /models at retirement
-            # time; if a later refresh sees it back in the free section, OpenCode
-            # has not actually removed it -- the outage was transient upstream
-            # overload, exactly the case the auto-recycle must NOT lock out for
-            # the full TTL (7 days) just because it 400'd once. Reconcile only
-            # against authoritative (non-stale) provider fetches, so a fallback
-            # to the cached last-good list cannot resurrect an id the upstream
-            # genuinely stopped offering. Operator-seeded ids are left alone: the
-            # seed exists precisely because /models keeps advertising a model the
-            # operator knows is dead, so the live list is not authoritative for
-            # it.
+            # Self-heal runtime retirements against the live free section,
+            # gated by a probation window: a -free model retired at runtime
+            # 400'd "unavailable" while chat refused to serve it; the
+            # recycler parked it including the chronic case where /models
+            # keeps advertising it. Without probation the self-heal here
+            # would resurrect it on the NEXT refresh (~CATALOG_TTL) and the
+            # retirement would last seconds -- so the probation floor holds
+            # a chronic offender parked for RETIRED_MODEL_PROBATION_S, after
+            # which a live non-stale re-list is allowed to bring it back.
+            # That window is also what keeps a *transient* "unavailable"
+            # burst self-healable in minutes instead of the full TTL the old
+            # "trust /models" gate used to lock out working models for.
+            # Reconcile only against authoritative (non-stale) provider
+            # fetches, so a fallback to the cached last-good list cannot
+            # resurrect an id the upstream genuinely stopped offering.
+            # Operator-seeded ids are left alone: the seed exists precisely
+            # because /models keeps advertising a model the operator knows is
+            # dead, so the live list is not authoritative for it.
+            probation = config.RETIRED_MODEL_PROBATION_S
             reconciled = False
             for mid in list(self._unavailable):
                 if mid in self._seed_ids:
+                    continue
+                parked_at = self._unavailable.get(mid, now)
+                if probation > 0 and (now - parked_at) < probation:
                     continue
                 lm = logical.get(mid)
                 if lm is None:

--- a/backend/tests/test_routing.py
+++ b/backend/tests/test_routing.py
@@ -3593,16 +3593,17 @@ def _fetch_provider_factory():
 
 
 def test_unit_a_retired_model_self_heals_when_opencode_re_lists_it(tmp_path, monkeypatch):
-    """The auto-recycle must not lock out a model OpenCode still offers free.
+    """The auto-recycle (probation=0) resurrects a re-listed retired model on
+    the next live refresh, instead of hiding it for the full TTL.
 
-    A ``-free`` model retired at runtime was absent from /models when it 400'd;
-    if a later refresh sees it back in the free section the outage was transient
-    upstream overload (OpenCode pulls a genuinely-dropped model from the free
-    section outright -- it doesn't answer "unavailable" for one it removed), so
-    the catalog resurrects it immediately instead of hiding it for the full TTL.
-    Only a model genuinely gone from the free section stays retired. This is the
-    behavior that keeps deepseek-v4-flash-free routable during huge-traffic
-    overload instead of recycling it for a week."""
+    A ``-free`` model retired at runtime (its free-tier chat 400'd
+    'unavailable') was parked; probation=0 collapses the chronic (still
+    listed, backend refuses chat) and genuine (gone from /models) cases to
+    'park once, resurrect on the next non-stale re-list', so a transient
+    upstream blip self-heals in one refresh. probation>0 (the default 300s)
+    holds chronic offenders parked for the probation window instead -- the
+    subject of its own test. Only a model genuinely gone from the free section
+    stays retired even when probation is 0."""
     from core import config as core_config
 
     FetchProvider, UnifiedCatalog = _fetch_provider_factory()
@@ -3610,13 +3611,16 @@ def test_unit_a_retired_model_self_heals_when_opencode_re_lists_it(tmp_path, mon
     monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
     monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
     monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
+    # Probation off: this test exercises the immediate-resurrection path
+    # (a re-listed retired model comes back on the very next live refresh).
+    # The probation window's behavior is pinned by its own test below.
+    monkeypatch.setattr(core_config, "RETIRED_MODEL_PROBATION_S", 0.0)
 
     prov = FetchProvider()
     cat = UnifiedCatalog({"opencode": prov})
 
     # Live free section lists both; retire one via the runtime path
-    # (mark_unavailable is what _flag_model_retired calls after a 400 once a
-    # refresh confirms the model is gone).
+    # (mark_unavailable is what _flag_model_retired calls after a 400).
     prov._ids = ["good-free", "dead-free"]
     cat.refresh(force=True)
     assert sorted(m.id for m in cat.free()) == ["dead-free", "good-free"]
@@ -3663,6 +3667,9 @@ def test_unit_runtime_retirement_not_resurrected_from_stale_fetch(tmp_path, monk
     monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
     monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
     monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
+    # Probation off so the resurrection gate tested here is staleness alone,
+    # not the probation window (its own test below pins that path).
+    monkeypatch.setattr(core_config, "RETIRED_MODEL_PROBATION_S", 0.0)
 
     prov = FetchProvider()
     cat = UnifiedCatalog({"opencode": prov})
@@ -3709,12 +3716,13 @@ def test_unit_seeded_retirement_survives_re_listing(tmp_path, monkeypatch):
     assert cat.is_unavailable("seeded-free") is True
 
 
-def test_unit_app_flags_a_model_retired_only_when_gone_from_free_section(monkeypatch):
-    """Retirement is reserved for a model OpenCode actually dropped from the
-    free section. A "-free" model that 400s "unavailable" while *still listed*
-    is transient overload -- it stays routable. So _flag_model_retired forces a
-    refresh and retires ONLY when by_id comes back None. Other 400s and 429s do
-    not even refresh (no retirement, and no /models hammering on a non-match)."""
+def test_unit_app_flags_model_retired_on_unavailable_400_still_listed_or_not(monkeypatch):
+    """The recycler retires a -free model on a 'Model is unavailable' 400 even
+    when OpenCode keeps advertising it in /models -- the chronic
+    deepseek/musespark case ('still listed, but the backend refuses chat').
+    by_id is no longer consulted as a retirement gate; the probation-aware
+    self-heal in refresh() is what resurrects such a model later if OpenCode
+    genuinely restores the chat. Other 400s and 429s don't even mark."""
     import app as app_mod
     from providers.base import UpstreamError
     from routing import executor as exec_mod
@@ -3725,15 +3733,10 @@ def test_unit_app_flags_a_model_retired_only_when_gone_from_free_section(monkeyp
     class FakeCat:
         def __init__(self):
             self.marked = []
-            self.refresh_calls = 0
-            self._gone = set()      # ids by_id reports as None (dropped from free)
+            self._gone = set()  # ids whose /models membership has been dropped
 
-        def refresh(self, force=False):
-            self.refresh_calls += 1
-            return self
-
-        def by_id(self, mid):
-            return None if mid in self._gone else object()  # truthy = still listed
+        def by_id(self, mid):  # consulted only for log flavor; not a gate.
+            return None if mid in self._gone else object()
 
         def mark_unavailable(self, mid):
             self.marked.append(mid)
@@ -3747,49 +3750,48 @@ def test_unit_app_flags_a_model_retired_only_when_gone_from_free_section(monkeyp
     def unavail(detail):
         return exec_mod.AllFailedError(UpstreamError(400, detail), [])
 
-    # Still listed -> transient overload -> NOT retired; refresh was consulted.
+    # Chronic case: model STILL listed in /models AND chat 400'd 'unavailable'.
+    # The OLD design left it routable here; the engine-fix parks it outright --
+    # the 400 is the retirement signal, /models membership is not consulted.
     assert app_mod._flag_model_retired(
         unavail("This model is unavailable for free. use inclusionai/ling-3.0-flash"),
         "ling-3.0-flash-free",
-    ) is False
-    assert cat.marked == []
-    assert cat.refresh_calls == 1
+    ) is True
+    assert cat.marked == ["ling-3.0-flash-free"]
 
-    # Same model, now genuinely dropped from the free section -> retired.
-    cat._gone.add("ling-3.0-flash-free")
-    # The previous call stamped the recheck clock; clear it so this iteration
-    # is allowed to recheck (the cooldown is exercised in its own test below).
+    # Genuinely dropped (by_id now None) -> identical retirement behavior: the
+    # gate is the 400 itself, not the /models membership.
+    cat._gone.add("muse-free")
     app_mod._retire_recheck_at.clear()
     assert app_mod._flag_model_retired(
         unavail("This model is unavailable for free."),
-        "ling-3.0-flash-free",
+        "muse-free",
     ) is True
-    assert cat.marked == ["ling-3.0-flash-free"]
-    assert cat.refresh_calls == 2
+    assert cat.marked == ["ling-3.0-flash-free", "muse-free"]
 
-    # A non-retirement 400 must not retire AND must not even refresh.
-    before = cat.refresh_calls
+    # A non-retirement 400 (no 'unavailable' in detail) -> not retired.
+    app_mod._retire_recheck_at.clear()
     assert app_mod._flag_model_retired(
         exec_mod.AllFailedError(UpstreamError(400, "bad request shape"), []),
         "x-free",
     ) is False
-    assert cat.refresh_calls == before              # no /models refresh on a non-match
-    assert cat.marked == ["ling-3.0-flash-free"]
+    assert cat.marked == ["ling-3.0-flash-free", "muse-free"]
 
-    # A 429 is not retirement either -- and also does not refresh.
+    # A 429 is not retirement either.
     assert app_mod._flag_model_retired(
         exec_mod.AllFailedError(UpstreamError(429, "rate limited"), []),
         "x-free",
     ) is False
-    assert cat.refresh_calls == before
+    assert cat.marked == ["ling-3.0-flash-free", "muse-free"]
 
 
 def test_unit_app_flags_model_retired_recheck_cooldown(monkeypatch):
-    """A transient "unavailable" burst (huge upstream traffic) fires the
-    free-section recheck on many concurrent requests at once. The per-model
-    cooldown bounds it to one refresh per window: a second call for the same
-    model within the cooldown returns False WITHOUT refreshing again, so a burst
-    can't hammer /models."""
+    """A transient 'unavailable' burst (huge upstream traffic) fires the
+    retirement attempt on many concurrent requests at once. The per-model
+    cooldown bounds it to one retirement decision per window: a second call
+    for the same model within the cooldown returns False WITHOUT calling
+    mark_unavailable again, so a burst can't churn the lock / persisted
+    retired set."""
     import app as app_mod
     from providers.base import UpstreamError
     from routing import executor as exec_mod
@@ -3798,20 +3800,13 @@ def test_unit_app_flags_model_retired_recheck_cooldown(monkeypatch):
 
     class FakeCat:
         def __init__(self):
-            self.refresh_calls = 0
-
-        def refresh(self, force=False):
-            self.refresh_calls += 1
-            return self
-
-        def by_id(self, mid):
-            return object()        # always still listed -> never retired here
+            self.mark_calls = 0
 
         def mark_unavailable(self, mid):
-            pass
+            self.mark_calls += 1
 
         def is_unavailable(self, mid):
-            return False
+            return False  # not yet parked before the first call fires
 
     cat = FakeCat()
     monkeypatch.setattr(app_mod, "catalog", cat)
@@ -3819,8 +3814,52 @@ def test_unit_app_flags_model_retired_recheck_cooldown(monkeypatch):
     exc = exec_mod.AllFailedError(
         UpstreamError(400, "This model is unavailable for free"), []
     )
+    # First call parks the model; an immediate second call is gated by the
+    # cooldown and MUST NOT call mark_unavailable again.
+    assert app_mod._flag_model_retired(exc, "muse-free") is True
+    assert cat.mark_calls == 1
     assert app_mod._flag_model_retired(exc, "muse-free") is False
-    assert cat.refresh_calls == 1
-    # Immediate second call -> cooldown skips the recheck entirely.
-    assert app_mod._flag_model_retired(exc, "muse-free") is False
-    assert cat.refresh_calls == 1
+    assert cat.mark_calls == 1
+
+
+def test_unit_a_retired_model_self_heal_holds_parked_within_probation(tmp_path, monkeypatch):
+    """The probation window keeps a runtime-retired model parked until
+    RETIRED_MODEL_PROBATION_S elapses, EVEN IF /models keeps advertising it
+    live throughout -- the chronic deepseek/musespark case ('still listed,
+    but the backend refuses chat'). Without probation the self-heal would
+    resurrect it on the very next refresh and the retirement would last
+    ~CATALOG_TTL. After probation elapses, a live non-stale re-list is allowed
+    to bring it back, so chronic offenders cycle parked -> retried -> re-parked
+    while a transient blip self-heals in PROBATION_S instead of the 7-day TTL
+    the old design locked out working models for."""
+    from core import config as core_config
+
+    FetchProvider, UnifiedCatalog = _fetch_provider_factory()
+
+    monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
+    monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
+    monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
+    monkeypatch.setattr(core_config, "RETIRED_MODEL_PROBATION_S", 300.0)
+
+    prov = FetchProvider()
+    cat = UnifiedCatalog({"opencode": prov})
+
+    prov._ids = ["good-free", "dead-free"]
+    cat.refresh(force=True)
+    cat.mark_unavailable("dead-free")
+    assert cat.is_unavailable("dead-free") is True
+
+    # /models keeps advertising it; inside the probation window self-heal
+    # must NOT resurrect it -- otherwise the retirement lasts only one refresh.
+    prov._ids = ["good-free", "dead-free"]
+    cat.refresh(force=True)
+    assert "dead-free" not in [m.id for m in cat.free()]
+    assert cat.is_unavailable("dead-free") is True
+
+    # Push the parked timestamp past the probation window: now a live non-stale
+    # refresh is allowed to resurrect it.
+    cat._unavailable["dead-free"] = time.time() - 600.0
+    prov._ids = ["good-free", "dead-free"]
+    cat.refresh(force=True)
+    assert "dead-free" in [m.id for m in cat.free()]
+    assert cat.is_unavailable("dead-free") is False


### PR DESCRIPTION
## What this fixes

Operator-reported bug: deepseek-v4-flash-free returns HTTP 400 "Model is unavailable", Lingling falls back to hy3-free, but the recycler stays silent and the model stays **everywhere** — dashboard picker, `/v1/models`, `/api/models`, sampler, dispatcher. The recycler's "trust `/models`" gate at `_flag_model_retired` forced a refresh and retired ONLY when `catalog.by_id(...)` came back None (OpenCode had fully pulled the listing from the free section). The chronic case (list says free, chat refuses) never retired, because OpenCode keeps advertising it.

## The change

- **`_flag_model_retired` (`app.py`)** — retire on the first qualifying `'unavailable'` 400 (status 400 + `'unavailable'` in the error detail). The `by_id` gate and the now-pointless force-refresh are gone. The 30s per-model cooldown stays, so a burst of concurrent 400s can't churn the lock.
- **Catalog self-heal (`catalog.py refresh()`)** — gate resurrection by a per-model probation window `LINGLING_RETIRED_MODEL_PROBATION_S` (default 300s): a parked model is NOT resurrected on a `/models` re-list until `parked_at` is older than the probation window.

Without probation, dropping the gate would self-heal a chronic offender back on the next refresh (~30s). The probation is the window that lets the recycler commit to a 400-based retire.

## Steady state

- **Chronic offender** (still listed, chat refuses): parked 5 min → self-heal pops → next chat retries → if it 400s again, the recycler re-parks with a fresh timestamp, starting another 5-min cycle. OpenCode actually restoring the chat ends the cycle.
- **Transient blip** (one-off 400 then back to normal): self-heals in 5 minutes instead of the seven-day lockdown the old "trust `/models`" design used to lock out deepseek/musespark for.
- `RETIRED_MODEL_TTL_DAYS` (7d) is now a load-time age cap; probation re-parks reset the timestamp so chronic offenders never age out, only entries idle for over a week get garbage-collected.

## Tests

Hermetic suite: **298 passed** (13 live deselected — no running gateway). Rewrote the two tests that pinned the old by_id-gated behavior; added a probation-window self-heal test. Immediate-resurrect test stays viable under `PROBATION_S=0`.

## Docs

README + ARCHITECTURE no longer claim "trusts `/models`, and so should you"; they describe the probation-aware cycle, the new knob, and reframe `RETIRED_MODEL_TTL_DAYS` as the age cap. Mermaid diagram reflects the probation-then-pop loop.

## Secrets

`backend/data/` stays gitignored (`.gitignore:11`); `api_keys.json` and `retired_models.json` confirmed masked via `git check-ignore -v` before commit; the staged diff has no `ll_`/`ghp_`/`sk_`/WARP-private-key patterns.