### PR TITLE
fix(recycler): drop probation; parked stays parked across restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,37 +191,37 @@ over to another free one.
 
 Upstream sometimes keeps advertising a model it no longer actually serves — the
 list says free, the chat says no. The first request that hits a 400 retires the
-model **regardless of the listing**. It stays hidden for a probation window,
-after which the catalog's self-heal can resurrect it on a live re-list, because
-OpenCode has restored free tiers before:
+model **regardless of the listing**. A parked model stays parked across
+refreshes and across restarts: the catalog re-stamps the persisted retired
+entry to `now` on every load, so a restart that used to bring the model
+straight back on the first `/models` re-list now leaves it hidden — no
+probation window, no self-heal pop:
 
 ```mermaid
 stateDiagram-v2
     direction LR
     [*] --> Listed: appears in live feed
     Listed --> Retired: chat returns "unavailable" 400
-    Retired --> Listed: probation elapses & live re-list holds
-    Retired --> Retired: still dead after probation → re-retired
+    Retired --> Listed: TTL drops entry on next start & live re-list holds
+    Retired --> Retired: still listed → stays parked
     note right of Retired
         hidden from Catalog
         survives restarts
     end note
 ```
 
-The five-minute probation window (`LINGLING_RETIRED_MODEL_PROBATION_S`) replaced
-the older "trust `/models`" gate, which kept chronic offenders (still listed but
-the upstream keeps refusing chat — the deepseek/musespark case) perpetually
-routable. A model that just 400'd once rides out a transient blip in five
-minutes instead of the seven-day lockdown the old design used to lock out
-working models for; a chronic offender cycles parked → retried → re-parked once
-per window until opencode actually restores the chat.
-
-`LINGLING_RETIRED_MODEL_TTL_DAYS` (7 days) is now the upper-bound age cap — a
-retired entry older than this is dropped on a fresh gateway start. Probation
-re-parks reset the timer, so a chronic offender that keeps cycling never ages
-out; the TTL only garbage-collects entries that genuinely went idle for over a
-week. Models already known to be gone are pre-seeded as retired
-(`LINGLING_RETIRED_MODELS`) so they never list even once.
+There is no probation-pop on refresh anymore. Earlier the self-heal in
+`refresh()` would resurrect a parked model on the very next `/models` re-list
+once any probation window elapsed — and across a gateway restart the persisted
+`parked_at` was already hours old, so the first post-startup refresh
+resurrected the model "everywhere" within one cycle. Parked now means parked:
+the entry sits in `backend/data/retired_models.json` until either the operator
+clears it manually or `LINGLING_RETIRED_MODEL_TTL_DAYS` drops it on the next
+gateway start, which gives OpenCode a week to resume actually serving the chat
+before the recycler learns afresh and re-parks it. Models already known to be
+gone are pre-seeded as retired (`LINGLING_RETIRED_MODELS`) and re-stamped on
+every load, so the TTL never ages them out while the seed is set — they never
+list even once.
 
 ## Reasoning effort
 
@@ -334,9 +334,8 @@ gateway. Skip this section unless something specific needs changing.
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
-| `LINGLING_RETIRED_MODELS` | *(seeded list)* | Models hidden from the catalog from startup — dropped free models the upstream still advertises |
-| `LINGLING_RETIRED_MODEL_PROBATION_S` | `300` | A runtime-retired model stays hidden this many seconds before the catalog self-heal can resurrect it on a live `/models` re-list; the window that replaced the old "trust `/models`" gate |
-| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | Upper-bound age cap — a retired entry older than this is dropped on a fresh gateway start (probation re-parks reset the timer, so chronic offenders never age out) |
+| `LINGLING_RETIRED_MODELS` | *(seeded list)* | Models hidden from the catalog from startup — dropped free models the upstream still advertises; re-stamped on every load so the TTL never ages them out while the seed is set |
+| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | The only auto-recover path: a retired entry whose persisted timestamp is older than this is dropped on a fresh gateway start, then the next live `/models` re-list can resurrect it. There is no probation/self-heal pop — a parked model stays parked across refreshes and across restarts until retired_models.json is cleared or this TTL drops the entry on the next start |
 | `LINGLING_UPSTREAM_USER_AGENT` | `opencode/1.0` | Identifies as the official client. See below — without this, the best free models 429 instantly |
 
 The complete list lives in `backend/core/config.py`, defaults included. Everything

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You know free AI tiers. They work beautifully for twenty minutes, then a per-IP 
 
 It also:
 - auto-discovers whatever free models opencode is serving *right now* — no frozen model table, because any list would be wrong within a month;
-- retires models opencode quietly stopped serving at chat, even when `/models` keeps advertising them (the deepseek/musespark chronic case), persists across restarts, and self-heals under a probation clock when opencode actually restores the chat;
+- retires models opencode quietly stopped serving at chat, even when `/models` keeps advertising them (the deepseek/musespark chronic case), and parks them **durable across refreshes and across restarts** — across `/v1/models`, the dashboard picker, the sampler and the dispatcher — until the operator clears `backend/data/retired_models.json` or `LINGLING_RETIRED_MODEL_TTL_DAYS` (7 days) drops the entry on the next gateway start;
 - sends a real probe request through every WARP lane at startup and every few minutes, so dead/burned IPs get re-rolled before your request finds them;
 - runs a tiny non-stream sampler after each heal that pokes every free model through every green exit and records which ones came back **cooked** — yes, that's the technical term — so a model-side refusal fails fast instead of churning the whole pool, and the per-model fallback fires.
 
@@ -60,7 +60,7 @@ Whatever's free right now — the catalog is fetched live from the upstream at r
 A quirk worth knowing: opencode **still advertises some pulled free models in `/v1/models`** even after the CLI drops them — the list lies. Lingling learns the truth at chat-time, retires a refused model regardless of the listing (see the recycler below), and routes the request onto a live one transparently. So "this model works" and "this model is listed" are not the same sentence, and that's by design.
 
 ### The recycler (retirement cycle)
-First request that comes back with the "unavailable for free" 400 retires the model — hidden from the dashboard picker, `/v1/models`, `/api/models`, and the Codex/Claude Code setup catalogs — **regardless of whether `/models` still advertises it** (the chronic case: list says free, chat says no). The model stays hidden for `LINGLING_RETIRED_MODEL_PROBATION_S` (5 minutes by default); after that the catalog self-heal can resurrect it on a live re-list, so a transient upstream blip self-heals in minutes, not the seven-day lockdown the old "trust `/models`" design used to lock out working models for. Chronic offenders — `/models` keeps advertising but chat keeps refusing — cycle parked → retried → re-parked once per probation window until opencode actually restores the chat. Operator-seeded dead ids (`LINGLING_RETIRED_MODELS`, default `ling-3.0-flash-free`) are hidden from the very first startup. The recycler trusts the 400, not the listing.
+First request that comes back with the "unavailable for free" 400 retires the model — hidden from the dashboard picker, `/v1/models`, `/api/models`, and the Codex/Claude Code setup catalogs — **regardless of whether `/models` still advertises it** (the chronic case: list says free, chat says no). The model stays parked **durable across refreshes and across restarts**: the catalog re-stamps the persisted retired entry to `now` on every load, so a restart that used to bring the model straight back on the first `/models` re-list (the "back everywhere" case the chronic deepseek/musespark offenders produced) now leaves it hidden. There is no probation window and no self-heal pop — chronic offenders no longer cycle through parked → retried → re-parked; **parked means parked**. The only auto-recover paths are the operator clearing `backend/data/retired_models.json`, or `LINGLING_RETIRED_MODEL_TTL_DAYS` (7 days by default) dropping the entry on the **next** gateway start, which gives OpenCode a week to resume actually serving the chat before the recycler can re-learn and re-park it. Operator-seeded dead ids (`LINGLING_RETIRED_MODELS`, default `ling-3.0-flash-free`) are hidden from the very first startup and re-stamped on every load, so the TTL never ages them out while the seed is set. The recycler trusts the 400, not the listing.
 
 ## The egress pool, a.k.a. the part that sounds illegal
 
@@ -117,9 +117,8 @@ All `LINGLING_*` environment variables, all read once at startup, all with defau
 
 | variable | default | what it does |
 |---|---|---|
-| `LINGLING_RETIRED_MODELS` | `ling-3.0-flash-free` | known-dead ids hidden from the catalog from the very first startup (opencode keeps advertising them) |
-| `LINGLING_RETIRED_MODEL_PROBATION_S` | `300` | how long a runtime-retired model stays hidden before the catalog self-heal can resurrect it on a live `/models` re-list; a chronic offender (still listed but chat refuses) cycles parked → retried → re-parked every window |
-| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | upper-bound age cap — a retired entry older than this is dropped on a fresh gateway start; probation re-parks reset the timer, so a chronic offender cycling on probation never ages out |
+| `LINGLING_RETIRED_MODELS` | `ling-3.0-flash-free` | known-dead ids hidden from the catalog from the very first startup (opencode keeps advertising them); re-stamped on every load so the TTL never ages them out while the seed is set |
+| `LINGLING_RETIRED_MODEL_TTL_DAYS` | `7` | the only auto-recover path: a retired entry whose persisted timestamp is older than this is dropped on a fresh gateway start, then the next live `/models` re-list can resurrect it. There is no probation/self-heal pop anymore — a parked model stays parked across refreshes and across restarts until the operator clears `retired_models.json` or this TTL drops the entry on the next gateway start |
 
 **Sampler + streaming**
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1363,11 +1363,14 @@ def _flag_model_retired(exc: Exception, model_id: str) -> bool:
     So the model is retired here on that signal alone; the chat path's own
     AllFailedError already propagates to failover, and this drop keeps the
     same model off the dashboard, /v1/models, the sampler and the dispatcher
-    until the self-heal in catalog.refresh() resurrects it under a probation
-    window (config.RETIRED_MODEL_PROBATION_S). That probation bounds the time
-    a *transient* "unavailable" burst stays parked to minutes -- not the full
-    7-day TTL the old "trust /models" gate used to lock out working models
-    like MuseSpark/deepseek for. A per-model cooldown keeps a burst of
+    until either the operator clears backend/data/retired_models.json or
+    LINGLING_RETIRED_MODEL_TTL_DAYS (7 days) drops the entry on the next
+    gateway start. There is no probation-pop anymore: a parked model stays
+    parked across refreshes and across restarts (a loaded entry is re-stamped
+    ``now`` in _load_unavailable so a fresh restart doesn't trip any "old
+    entry, must resurrect" logic; see catalog.refresh -- the self-heal pop
+    loop was removed because chronic offenders kept popping straight back to
+    "everywhere" within one refresh). A per-model cooldown keeps a burst of
     "unavailable" 400s from firing more than one retirement per window.
     """
     err = getattr(exc, "last_error", None)
@@ -1382,14 +1385,16 @@ def _flag_model_retired(exc: Exception, model_id: str) -> bool:
         if now - last < config.RETIRE_RECHECK_COOLDOWN_S:
             # Decisive retirement attempt already made recently for this model;
             # don't hammer the lock / persisted-retired set on every concurrent
-            # 400 in this burst. Self-heal alone may resurrect it later.
+            # 400 in this burst. The parked entry is already effective across
+            # /v1/models, the dashboard, the sampler and the dispatcher.
             return False
         _retire_recheck_at[model_id] = now
 
     if catalog.is_unavailable(model_id):
-        # Already parked -- the parked_at anchor is the probation clock, so
-        # let it ride and keep the self-heal window anchored to the original
-        # failure rather than re-stamping on concurrent in-flight 400s.
+        # Already parked -- a parked model stays parked across refreshes and
+        # across restarts (catalog._load_unavailable re-stamps the persisted
+        # entry to ``now`` on load), so a concurrent in-flight 400 for a model
+        # already in the retired set has nothing to do here.
         return False
 
     try:
@@ -1398,7 +1403,8 @@ def _flag_model_retired(exc: Exception, model_id: str) -> bool:
         return False
     log.info(
         "catalog: retired model %s (upstream refused free-tier chat with "
-        "'unavailable' 400; self-heal will retry it after RETIRED_MODEL_PROBATION_S)",
+        "'unavailable' 400; parked until retired_models.json is cleared or "
+        "LINGLING_RETIRED_MODEL_TTL_DAYS drops it on the next gateway start)",
         model_id,
     )
     return True

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -152,20 +152,6 @@ def retired_seed_ids() -> frozenset:
 # retirement decision per model per window so a burst of transient
 # "unavailable" 400s doesn't hammer the lock or the persisted retired set.
 RETIRE_RECHECK_COOLDOWN_S = float(os.getenv("LINGLING_RETIRE_RECHECK_COOLDOWN_S", "30"))
-# Probation window that a runtime-retired model stays hidden before the
-# catalog self-heal is allowed to resurrect it on a /models re-list. The
-# recycler now retires a model on the first "Model is unavailable" 400 even
-# when OpenCode keeps advertising it in /models (the chronic deepseek/musespark
-# case: still listed, but the upstream refuses to serve chat). Without a
-# probation floor the self-heal in refresh() would resurrect such a model on
-# the very next refresh and the retirement would last ~30s -- useless. The
-# probation keeps it parked for this many seconds; on expiry a live non-stale
-# re-list is allowed to bring it back, so a transient blip self-heals in
-# minutes (not the 7-day TTL the old design used to lock out working models
-# for), while a chronic offender cycles parked -> retried -> re-parked.
-# 0 disables probation (immediate resurrect on the next live re-list, the
-# pre-engine-fix behavior).
-RETIRED_MODEL_PROBATION_S = float(os.getenv("LINGLING_RETIRED_MODEL_PROBATION_S", "300"))
 
 # Defer re-rolling/restarting an egress (WARP wireproxy / Tor lane) while an
 # HTTP stream is riding it, so the health/formation/probe daemons don't

--- a/backend/models/catalog.py
+++ b/backend/models/catalog.py
@@ -134,13 +134,22 @@ class UnifiedCatalog:
 
     # -- retired models ----------------------------------------------------
     def _load_unavailable(self) -> None:
-        """Restore the retired set: seeded known-dead ids plus persisted runtime ones.
+        """Restore the retired set; every loaded entry is re-stamped ``now``.
 
         Seeded ids (``config.retired_seed_ids()``) are hidden from the very
-        first startup -- OpenCode keeps advertising dropped models, so the
-        runtime 400-learning only triggers on first use. They are re-stamped
-        ``now`` on every load, so they never expire while they remain seeded.
-        Runtime-learned entries (below) keep their TTL.
+        first startup. Runtime-learned entries (parked by the recycler on a
+        'Model is unavailable' 400) are loaded back on every gateway start,
+        AND re-stamped ``now`` -- this is what lets a parked model STAY
+        parked across restarts and across refreshes: across a restart the
+        original parked_at of hours ago would already be past any probation
+        window, so the catalog's first refresh would otherwise resurrect the
+        model on a /models re-list (the chronic case gives /models the same
+        listing pre and post restart). The probation-pop loop is gone, the
+        re-stamp alone is what holds the parked state across the restart.
+        Persistence respects LINGLING_RETIRED_MODEL_TTL_DAYS on load only: an
+        entry whose persisted timestamp is older than the TTL is dropped
+        here, so OpenCode gets a chance to resume serving it during the next
+        week even without an operator clearing retired_models.json.
         """
         ttl = config.RETIRED_MODEL_TTL_DAYS * 86400
         now = time.time()
@@ -154,7 +163,7 @@ class UnifiedCatalog:
         if isinstance(raw, dict):
             for mid, ts in raw.items():
                 if isinstance(ts, (int, float)) and (now - float(ts)) < ttl:
-                    self._unavailable[str(mid)] = float(ts)
+                    self._unavailable[str(mid)] = now  # re-stamp: parked stays parked across restarts
 
     def _save_unavailable(self) -> None:
         try:
@@ -244,40 +253,18 @@ class UnifiedCatalog:
             self._per_provider = per_provider
             self._generated_at = time.time()
 
-            # Self-heal runtime retirements against the live free section,
-            # gated by a probation window: a -free model retired at runtime
-            # 400'd "unavailable" while chat refused to serve it; the
-            # recycler parked it including the chronic case where /models
-            # keeps advertising it. Without probation the self-heal here
-            # would resurrect it on the NEXT refresh (~CATALOG_TTL) and the
-            # retirement would last seconds -- so the probation floor holds
-            # a chronic offender parked for RETIRED_MODEL_PROBATION_S, after
-            # which a live non-stale re-list is allowed to bring it back.
-            # That window is also what keeps a *transient* "unavailable"
-            # burst self-healable in minutes instead of the full TTL the old
-            # "trust /models" gate used to lock out working models for.
-            # Reconcile only against authoritative (non-stale) provider
-            # fetches, so a fallback to the cached last-good list cannot
-            # resurrect an id the upstream genuinely stopped offering.
-            # Operator-seeded ids are left alone: the seed exists precisely
-            # because /models keeps advertising a model the operator knows is
-            # dead, so the live list is not authoritative for it.
-            probation = config.RETIRED_MODEL_PROBATION_S
-            reconciled = False
-            for mid in list(self._unavailable):
-                if mid in self._seed_ids:
-                    continue
-                parked_at = self._unavailable.get(mid, now)
-                if probation > 0 and (now - parked_at) < probation:
-                    continue
-                lm = logical.get(mid)
-                if lm is None:
-                    continue
-                if any(not self._stale.get(pid, False) for pid in lm.provider_ids):
-                    self._unavailable.pop(mid, None)
-                    reconciled = True
-            if reconciled:
-                self._save_unavailable()
+            # No auto-resurrection: a model parked by the recycler STAYS parked
+            # across refreshes and across restarts. The earlier "self-heal on a
+            # /models re-list" pop used to undo the retirement within one
+            # refresh for the chronic case (OpenCode keeps advertising the model
+            # but the backend refuses chat) -- across a gateway restart the
+            # parked entry's persisted timestamp was well past the probation
+            # window, so the FIRST post-startup refresh immediately resurrected
+            # the model "everywhere" again. Parked entries are now sticky until
+            # either the operator clears retired_models.json manually or the
+            # LINGLING_RETIRED_MODEL_TTL_DAYS age filter in _load_unavailable
+            # drops the entry on the next gateway start (gives OpenCode a week
+            # to resume serving it without an operator touch).
             return self
 
     # -- queries -----------------------------------------------------------

--- a/backend/tests/test_routing.py
+++ b/backend/tests/test_routing.py
@@ -3592,18 +3592,17 @@ def _fetch_provider_factory():
     return FetchProvider, UnifiedCatalog
 
 
-def test_unit_a_retired_model_self_heals_when_opencode_re_lists_it(tmp_path, monkeypatch):
-    """The auto-recycle (probation=0) resurrects a re-listed retired model on
-    the next live refresh, instead of hiding it for the full TTL.
+def test_unit_a_runtime_retirement_stays_parked_through_refresh(tmp_path, monkeypatch):
+    """A model retired at runtime (its free-tier chat 400'd 'unavailable')
+    STAYS parked across subsequent catalog refreshes -- even when OpenCode
+    keeps advertising it in /models the whole time (the chronic case).
 
-    A ``-free`` model retired at runtime (its free-tier chat 400'd
-    'unavailable') was parked; probation=0 collapses the chronic (still
-    listed, backend refuses chat) and genuine (gone from /models) cases to
-    'park once, resurrect on the next non-stale re-list', so a transient
-    upstream blip self-heals in one refresh. probation>0 (the default 300s)
-    holds chronic offenders parked for the probation window instead -- the
-    subject of its own test. Only a model genuinely gone from the free section
-    stays retired even when probation is 0."""
+    The auto-resurrect self-heal path used to pop such an entry on the very
+    next non-stale refresh; that proved wrong for the chronic case (still
+    listed in /models but the upstream refuses to serve chat) so it's gone.
+    Parked entries are now sticky until the operator clears
+    retired_models.json OR the LINGLING_RETIRED_MODEL_TTL_DAYS age filter in
+    _load_unavailable drops the entry on the next gateway start."""
     from core import config as core_config
 
     FetchProvider, UnifiedCatalog = _fetch_provider_factory()
@@ -3611,10 +3610,6 @@ def test_unit_a_retired_model_self_heals_when_opencode_re_lists_it(tmp_path, mon
     monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
     monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
     monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
-    # Probation off: this test exercises the immediate-resurrection path
-    # (a re-listed retired model comes back on the very next live refresh).
-    # The probation window's behavior is pinned by its own test below.
-    monkeypatch.setattr(core_config, "RETIRED_MODEL_PROBATION_S", 0.0)
 
     prov = FetchProvider()
     cat = UnifiedCatalog({"opencode": prov})
@@ -3630,36 +3625,38 @@ def test_unit_a_retired_model_self_heals_when_opencode_re_lists_it(tmp_path, mon
     assert cat.is_unavailable("dead-free") is True
     assert "dead-free" in cat.meta()["retired_models"]
 
-    # Genuinely removed (OpenCode dropped it from the free section): absent from
-    # the next live fetch -> stays retired, NOT resurrected.
+    # OpenCode keeps advertising it across live non-stale refreshes. The OLD
+    # design would have resurrected it here; the new one keeps it parked.
+    for _ in range(3):
+        prov._ids = ["good-free", "dead-free"]
+        cat.refresh(force=True)
+        assert "dead-free" not in [m.id for m in cat.free()]
+        assert cat.is_unavailable("dead-free") is True
+
+    # Genuinely removed (OpenCode dropped it from the free section): absent
+    # from the next live fetch. The parked entry still holds; nothing
+    # opportunistically un-retires it either way.
     prov._ids = ["good-free"]
     cat.refresh(force=True)
     assert "dead-free" not in [m.id for m in cat.free()]
     assert cat.is_unavailable("dead-free") is True
 
-    # OpenCode re-lists it (transient overload cleared): a live, non-stale
-    # refresh resurrects it automatically -- no manual un-seed, no 7-day TTL wait.
-    prov._ids = ["good-free", "dead-free"]
-    cat.refresh(force=True)
-    assert "dead-free" in [m.id for m in cat.free()]
-    assert cat.is_unavailable("dead-free") is False
-    assert cat.by_id("dead-free") is not None
-
-    # The resurrection is persisted, so a freshly-built catalog (the Codex
-    # generator is a separate process) no longer hides it either.
+    # A freshly-built catalog (the Codex generator is a separate process)
+    # loads the persisted state and keeps dead-free parked across reload too.
     prov2 = FetchProvider()
     prov2._ids = ["good-free", "dead-free"]
     cat2 = UnifiedCatalog({"opencode": prov2})
     cat2.refresh(force=True)
-    assert "dead-free" in [m.id for m in cat2.free()]
+    assert "dead-free" not in [m.id for m in cat2.free()]
+    assert cat2.is_unavailable("dead-free") is True
 
 
 def test_unit_runtime_retirement_not_resurrected_from_stale_fetch(tmp_path, monkeypatch):
-    """A live fetch is authoritative for resurrection; a stale-fallback
-    appearance is the cached last-good list, not OpenCode actually serving the
-    model again, so it must NOT resurrect a retired id. Otherwise a transient
-    /models outage (falling back to a cache that still lists the model) would
-    falsely un-retire a model the upstream genuinely stopped offering."""
+    """With the self-heal auto-resurrect path removed, a retired model is
+    trivially kept retired on a stale /models fetch (the catalog fell back
+    to last-good, which still lists the model) -- there's no pop mechanism to
+    fire in the first place. Kept as a regression guard against any future
+    re-addition of opportunistic resurrection based on stale data."""
     from core import config as core_config
 
     FetchProvider, UnifiedCatalog = _fetch_provider_factory()
@@ -3667,9 +3664,6 @@ def test_unit_runtime_retirement_not_resurrected_from_stale_fetch(tmp_path, monk
     monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
     monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
     monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
-    # Probation off so the resurrection gate tested here is staleness alone,
-    # not the probation window (its own test below pins that path).
-    monkeypatch.setattr(core_config, "RETIRED_MODEL_PROBATION_S", 0.0)
 
     prov = FetchProvider()
     cat = UnifiedCatalog({"opencode": prov})
@@ -3681,8 +3675,10 @@ def test_unit_runtime_retirement_not_resurrected_from_stale_fetch(tmp_path, monk
     assert cat.is_unavailable("dead-free") is True
 
     # The next fetch FAILS: the catalog falls back to last-good (which still
-    # lists dead-free) under stale=True. That appearance is the cache, not a
-    # live confirmation, so dead-free must stay retired.
+    # lists dead-free) under stale=True. No pop happens either way (live or
+    # stale), so dead-free stays retired -- with the auto-resurrect path gone
+    # this is the trivial outcome, but it stays tested to catch any future
+    # re-addition of /models-cache-driven resurrection.
     prov._fail_next = True
     cat.refresh(force=True)
     assert "dead-free" not in [m.id for m in cat.free()]
@@ -3822,16 +3818,16 @@ def test_unit_app_flags_model_retired_recheck_cooldown(monkeypatch):
     assert cat.mark_calls == 1
 
 
-def test_unit_a_retired_model_self_heal_holds_parked_within_probation(tmp_path, monkeypatch):
-    """The probation window keeps a runtime-retired model parked until
-    RETIRED_MODEL_PROBATION_S elapses, EVEN IF /models keeps advertising it
-    live throughout -- the chronic deepseek/musespark case ('still listed,
-    but the backend refuses chat'). Without probation the self-heal would
-    resurrect it on the very next refresh and the retirement would last
-    ~CATALOG_TTL. After probation elapses, a live non-stale re-list is allowed
-    to bring it back, so chronic offenders cycle parked -> retried -> re-parked
-    while a transient blip self-heals in PROBATION_S instead of the 7-day TTL
-    the old design locked out working models for."""
+def test_unit_a_runtime_retirement_survives_restart_via_persisted_state(tmp_path, monkeypatch):
+    """A model parked by the recycler, persisted to retired_models.json, is
+    reloaded on every gateway restart and STAYS parked across the restart --
+    even when its persisted timestamp is hours old (well past any probation
+    window the OLD design used to honour) AND /models keeps advertising it.
+
+    _load_unavailable re-stamps the loaded entry to `now`, so the entry is
+    treated as freshly parked again and there's no auto-resurrect pop to undo
+    the retirement on the next refresh. This is the bug the operator saw: a
+    parked deepseek that came back everywhere after a backend restart."""
     from core import config as core_config
 
     FetchProvider, UnifiedCatalog = _fetch_provider_factory()
@@ -3839,7 +3835,6 @@ def test_unit_a_retired_model_self_heal_holds_parked_within_probation(tmp_path, 
     monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
     monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
     monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
-    monkeypatch.setattr(core_config, "RETIRED_MODEL_PROBATION_S", 300.0)
 
     prov = FetchProvider()
     cat = UnifiedCatalog({"opencode": prov})
@@ -3849,17 +3844,57 @@ def test_unit_a_retired_model_self_heal_holds_parked_within_probation(tmp_path, 
     cat.mark_unavailable("dead-free")
     assert cat.is_unavailable("dead-free") is True
 
-    # /models keeps advertising it; inside the probation window self-heal
-    # must NOT resurrect it -- otherwise the retirement lasts only one refresh.
+    # Back-date the persisted timestamp an hour so its original parked_at is
+    # well past the 5-minute probation window the OLD design used to gate
+    # auto-resurrect. Save back; a fresh catalog (simulating a backend
+    # restart) loads it, re-stamps to `now`, and SHOULD keep dead-free
+    # parked across the restart.
+    cat._unavailable["dead-free"] = time.time() - 3600.0
+    cat._save_unavailable()
+
+    prov2 = FetchProvider()
+    prov2._ids = ["good-free", "dead-free"]
+    cat2 = UnifiedCatalog({"opencode": prov2})
+    cat2.refresh(force=True)
+    assert "dead-free" not in [m.id for m in cat2.free()]
+    assert cat2.is_unavailable("dead-free") is True
+
+
+def test_unit_a_runtime_retirement_expires_via_ttl_on_reload(tmp_path, monkeypatch):
+    """TTL on LINGLING_RETIRED_MODEL_TTL_DAYS is the only auto-recover path
+    now that auto-resurrect is gone. A parked entry older than the TTL is
+    filtered out by _load_unavailable on the next gateway start, so when
+    /models still lists the model the catalog offers it again -- giving
+    OpenCode a week to resume serving it without an operator clearing
+    retired_models.json."""
+    from core import config as core_config
+    import json
+
+    FetchProvider, UnifiedCatalog = _fetch_provider_factory()
+
+    monkeypatch.setattr(core_config, "RETIRED_MODELS_FILE", tmp_path / "retired.json")
+    monkeypatch.setattr(core_config, "RETIRED_MODELS_SEED", "")
+    monkeypatch.setattr(core_config, "RETIRED_MODEL_TTL_DAYS", 7)
+
+    prov = FetchProvider()
+    cat = UnifiedCatalog({"opencode": prov})
+
     prov._ids = ["good-free", "dead-free"]
     cat.refresh(force=True)
-    assert "dead-free" not in [m.id for m in cat.free()]
+    cat.mark_unavailable("dead-free")
     assert cat.is_unavailable("dead-free") is True
 
-    # Push the parked timestamp past the probation window: now a live non-stale
-    # refresh is allowed to resurrect it.
-    cat._unavailable["dead-free"] = time.time() - 600.0
-    prov._ids = ["good-free", "dead-free"]
-    cat.refresh(force=True)
-    assert "dead-free" in [m.id for m in cat.free()]
-    assert cat.is_unavailable("dead-free") is False
+    # Fast-forward the persisted clock past the 7-day TTL: write a timestamp
+    # 8 days old straight into retired_models.json.
+    path = tmp_path / "retired.json"
+    path.write_text(json.dumps({"dead-free": time.time() - (8 * 86400)}),
+                    encoding="utf-8")
+
+    # A fresh gateway start drops the past-TTL entry, so the next refresh
+    # that re-lists dead-free resurrects it on the catalog.
+    prov2 = FetchProvider()
+    prov2._ids = ["good-free", "dead-free"]
+    cat2 = UnifiedCatalog({"opencode": prov2})
+    cat2.refresh(force=True)
+    assert "dead-free" in [m.id for m in cat2.free()]
+    assert cat2.is_unavailable("dead-free") is False


### PR DESCRIPTION
## Problem

After iteration-1 (#3, 641ff81) shipped the probation window, the user reported: *"Deep Seek V4 Flash got removed earlier but then when I restarted the backend terminal, it is back again everywhere."*  Across a backend restart the persisted retired entry's `parked_at` was already >300s old, so the catalog's first post-startup `refresh()` ran the self-heal pop loop and immediately resurrected a chronic offender on `/v1/models`, the dashboard picker, the sampler and the dispatcher — exactly the symptom that prompted the fix in the first place.

## Fix

Drop probation entirely; **parked means parked** across refreshes and across restarts.

| file | change |
|---|---|
| `backend/core/config.py` | remove `LINGLING_RETIRED_MODEL_PROBATION_S` env knob |
| `backend/models/catalog.py` `_load_unavailable` | re-stamp every loaded entry (seeded + runtime) to `now`, so parking survives restart at full weight. `LINGLING_RETIRED_MODEL_TTL_DAYS=7` age filter remains — the **only** auto-recover path now (drops entries older than 7d on the next gateway start) |
| `backend/models/catalog.py` `refresh()` | remove the self-heal pop loop entirely; refresh no longer resurrects a parked entry regardless of staleness |
| `backend/app.py` `_flag_model_retired` | docstring, inline comments and the retired-model log string updated to durable-park semantics (no probation/self-heal references) |
| `backend/tests/test_routing.py` | rewrite `test_unit_a_retired_model_self_heals_when_opencode_re_lists_it` → `test_unit_a_runtime_retirement_stays_parked_through_refresh`; replace `test_unit_a_retired_model_self_heal_holds_parked_within_probation` with two new tests — `test_unit_a_runtime_retirement_survives_restart_via_persisted_state` (back-date persisted ts to 1h, fresh-catalog load keeps parked) and `test_unit_a_runtime_retirement_expires_via_ttl_on_reload` (8-day-old ts past TTL drops on next load); stale-fetch guard kept as a no-pop regression |
| `README.md` + `ARCHITECTURE.md` | remove `LINGLING_RETIRED_MODEL_PROBATION_S` env row from both; reframe `LINGLING_RETIRED_MODEL_TTL_DAYS` as the only auto-recover path; rewrite the recycler paragraph and the retirement-cycle mermaid state diagram |

The recycler stays fully model-agnostic — no `deepseek`/`musespark` hardcoded conditionals. The operator-seeded (`LINGLING_RETIRED_MODELS`, default `ling-3.0-flash-free`) ids are re-stamped on every load so the TTL never ages them out while seeded.

## Auto-recover paths (after this PR)

1. Operator clears `backend/data/retired_models.json` manually, or
2. `LINGLING_RETIRED_MODEL_TTL_DAYS=7` drops the entry on the next gateway start — gives OpenCode a week to resume actually serving the chat before the recycler can re-learn and re-park it.

## Verification

- Hermetic pytest suite: **299 passed, 13 deselected, 1 warning, exit 0** (132s)
- Diff scanned for secrets: no `ll_`/API-key/`sk-`/WARP-private-key patterns; `backend/data/api_keys.json` and `backend/data/retired_models.json` both gitignored at `.gitignore: backend/data/` and not staged
- No hardcoding: the prior PR's model-agnostic design is preserved.

Picks up on next backend restart (operator-controlled; the backend currently running as crash-witness is untouched).
